### PR TITLE
fix(web): stop static→dynamic 500s on the public site

### DIFF
--- a/apps/web/app/layout.js
+++ b/apps/web/app/layout.js
@@ -73,6 +73,15 @@ export const viewport = {
     colorScheme: "dark"
 };
 
+// SiteHeader (rendered on every route below) is an async server component
+// that reads per-request auth via cookies(). Under Next 16, a page that is
+// otherwise static-eligible (/, /careers, /faq, /terms, ...) gets statically
+// prerendered and then throws "Page changed from static to dynamic at runtime,
+// reason: cookies" at request time — a 500 on nearly every content page.
+// Since the shared header genuinely depends on the request cookies, no page
+// under this layout can be static; mark the whole tree dynamic.
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({ children }) {
     return (
         <html lang="en">


### PR DESCRIPTION
## Symptom
Nearly the entire public site (`/`, `/careers`, `/faq`, `/privacy`, `/terms`, `/protocol`, `/getting-started`, …) returns **HTTP 500** in production. `/api/health` and static assets stay **200**, so the server is up — this is an SSR render error, not infra/DNS.

## Root cause
`app/layout.js` renders `<SiteHeader/>`, an `async` server component that reads per-request auth via `getCurrentUser()` → `cookies()` (`lib/supabase/auth-server.js`). Under **Next 16**, content pages with no other dynamic signal get statically prerendered at build, then throw at request time:

```
Error: Page changed from static to dynamic at runtime, reason: cookies
https://nextjs.org/docs/messages/app-static-to-dynamic-error
```

Because the header lives in the root layout and depends on the request cookies, **no** page under this layout can legitimately be static.

## Fix
Add `export const dynamic = "force-dynamic"` to the root layout so the whole tree renders on demand.

## Verification
- `pnpm --filter @infernetprotocol/web build` compiles successfully with **no** static-to-dynamic errors.
- Every previously-500ing route now builds as `ƒ (Dynamic)` instead of `○ (Static)`.

Merging to `master` triggers the Railway redeploy that ships the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)