### PR TITLE
Stop contact-form spam that never renders the page

### DIFF
--- a/apps/web/app/api/contact/route.js
+++ b/apps/web/app/api/contact/route.js
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
+import { provenanceBlock, tagSubject } from "@profullstack/form-guard";
 import { parseAuthBody, wantsRedirect } from "@/lib/auth/parse-body";
 import { appUrl } from "@/lib/auth/app-url";
+import { contactGuard } from "@/lib/contact-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -21,16 +23,42 @@ export async function POST(request) {
     const body = await parseAuthBody(request);
     const wantHtml = wantsRedirect(request);
 
+    // Spam checks run before field validation on purpose. A bot that gets
+    // "all fields are required" back has learned what to send next time;
+    // one that gets a plain success has learned nothing at all.
+    const verdict = contactGuard
+        ? await contactGuard.check({ fields: body, headers: request.headers })
+        : null;
+
+    if (verdict && !verdict.allow) {
+        if (verdict.action === "drop") {
+            // Silently discarded. Reported as success so the sender cannot
+            // tell which check caught it.
+            console.warn(`contact: dropped submission (${verdict.reason}) ip=${verdict.ip ?? "?"}`);
+            return reply({ ok: true, sent: true, wantHtml, status: 200 });
+        }
+        if (verdict.action === "limited") {
+            return reply({
+                ok: false,
+                error: "Too many messages from this connection. Please try again later.",
+                wantHtml,
+                status: 429
+            });
+        }
+        // A real person whose token went stale or who submitted very
+        // fast. Ask them to send it again rather than losing it.
+        return reply({
+            ok: false,
+            error: "That took too long or came through too quickly. Please send it again.",
+            wantHtml,
+            status: 400
+        });
+    }
+
     const name = String(body.name ?? "").trim();
     const email = String(body.email ?? "").trim();
     const subject = String(body.subject ?? "").trim();
     const message = String(body.message ?? "").trim();
-    const honeypot = String(body.website ?? "").trim();
-
-    // Spam: bots fill the hidden honeypot. Pretend success.
-    if (honeypot) {
-        return reply({ ok: true, sent: true, wantHtml, status: 200 });
-    }
 
     if (!name || !email || !subject || !message) {
         return reply({
@@ -69,8 +97,8 @@ export async function POST(request) {
                 from: FROM,
                 to: [TO],
                 reply_to: email,
-                subject: `[contact] ${subject}`,
-                text: buildPlainBody({ name, email, subject, message })
+                subject: tagSubject(`[contact] ${subject}`, verdict ?? {}),
+                text: buildPlainBody({ name, email, subject, message, verdict })
             })
         });
         if (!res.ok) {
@@ -96,8 +124,8 @@ export async function POST(request) {
     return reply({ ok: true, sent: true, wantHtml, status: 200 });
 }
 
-function buildPlainBody({ name, email, subject, message }) {
-    return [
+function buildPlainBody({ name, email, subject, message, verdict }) {
+    const lines = [
         `From: ${name} <${email}>`,
         `Subject: ${subject}`,
         "",
@@ -105,7 +133,14 @@ function buildPlainBody({ name, email, subject, message }) {
         "",
         "—",
         "Sent from the contact form at https://infernetprotocol.com/contact"
-    ].join("\n");
+    ];
+    if (verdict) {
+        // Where the message came from and why it scored as it did. The
+        // mail headers cannot tell you any of this: the message is sent
+        // by us, to us, so it authenticates perfectly either way.
+        lines.push("", provenanceBlock({ ip: verdict.ip, userAgent: verdict.userAgent, verdict }));
+    }
+    return lines.join("\n");
 }
 
 // RFC 5322-strict is overkill — this catches obvious garbage; Resend

--- a/apps/web/app/contact/page.js
+++ b/apps/web/app/contact/page.js
@@ -1,3 +1,4 @@
+import { contactGuard } from "@/lib/contact-guard";
 
 export const metadata = {
     title: "Contact",
@@ -5,10 +6,17 @@ export const metadata = {
         "Get in touch with the Infernet Protocol team. Operator support, partnership inquiries, security disclosures."
 };
 
+// The form carries a token minted at render time, so the page must not be
+// cached — a stale page would hand every visitor the same expired token.
+export const dynamic = "force-dynamic";
+
 export default async function ContactPage({ searchParams }) {
     const params = (await searchParams) ?? {};
     const sent = params.sent === "1";
     const error = typeof params.error === "string" ? params.error : null;
+
+    const token = contactGuard ? await contactGuard.issue() : null;
+    const guardFields = token ? contactGuard.fields(token) : null;
 
     return (
         <>
@@ -64,11 +72,36 @@ export default async function ContactPage({ searchParams }) {
                             className="mt-2 block w-full rounded-lg border border-white/10 bg-[var(--panel-strong)] px-4 py-3 text-sm text-white outline-none ring-0 placeholder:text-[var(--muted)] focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/30"
                         />
                     </label>
-                    {/* Honeypot — bots fill any visible field, this one is hidden from humans. */}
-                    <label className="hidden" aria-hidden="true">
-                        Website
-                        <input type="text" name="website" tabIndex={-1} autoComplete="off" />
-                    </label>
+                    {guardFields ? (
+                        <>
+                            {/* Proof that this form was actually rendered. Without it
+                                a bot can POST straight at /api/contact and never see
+                                the honeypot below at all — which is how the spam that
+                                prompted this got through. */}
+                            <input
+                                type="hidden"
+                                name={guardFields.token.name}
+                                value={guardFields.token.value}
+                            />
+                            {/* Honeypot. Positioned off-canvas rather than
+                                display:none — some bots skip fields they can tell are
+                                not rendered, and this one should look real to them. */}
+                            <div
+                                aria-hidden="true"
+                                className="absolute -left-[9999px] h-px w-px overflow-hidden"
+                            >
+                                <label>
+                                    Website
+                                    <input
+                                        type="text"
+                                        name={guardFields.honeypot.name}
+                                        tabIndex={-1}
+                                        autoComplete="off"
+                                    />
+                                </label>
+                            </div>
+                        </>
+                    ) : null}
                     <button
                         type="submit"
                         className="w-full rounded-full bg-[var(--accent-strong)] px-6 py-3 text-sm font-semibold text-[var(--bg)] transition hover:bg-[var(--accent)]"

--- a/apps/web/lib/contact-guard.js
+++ b/apps/web/lib/contact-guard.js
@@ -1,0 +1,29 @@
+import "server-only";
+import { createFormGuard } from "@profullstack/form-guard";
+
+/**
+ * Shared guard for the public contact form.
+ *
+ * Both the page that renders the form and the route that receives it
+ * import this, so the token binding and the field names cannot drift
+ * apart — a mismatch there would reject every real submission silently.
+ *
+ * The secret never reaches the browser; only the signature does. It does
+ * have to be identical across every instance serving the form, so it
+ * falls back to RESEND_API_KEY, which this route already cannot work
+ * without and which is by definition the same everywhere.
+ */
+const secret = process.env.FORM_GUARD_SECRET ?? process.env.RESEND_API_KEY ?? "";
+
+export const contactGuard = secret
+    ? createFormGuard({
+          secret,
+          binding: "infernet:contact",
+          brandTerms: ["infernet protocol", "infernetprotocol"],
+          rateLimit: { max: 5, windowMs: 60 * 60 * 1000 },
+          // Enforcement is on by default. Set FORM_GUARD_ENFORCE=0 to fall
+          // back to scoring only, if a real sender ever reports being
+          // turned away.
+          requireToken: process.env.FORM_GUARD_ENFORCE !== "0"
+      })
+    : null;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@profullstack/favicon-generator": "^1.1.4",
+    "@profullstack/form-guard": "^0.1.0",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.49.8",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@profullstack/favicon-generator':
         specifier: ^1.1.4
         version: 1.1.4
+      '@profullstack/form-guard':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@supabase/ssr':
         specifier: ^0.10.2
         version: 0.10.2(@supabase/supabase-js@2.103.3)
@@ -1191,7 +1194,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.17.13':
     resolution: {integrity: sha512-n13yxOmI3I0JidzMdFCH68tYKGDtK4XlDFk1vysZX7AIRKeDVRsSbHhma5jCla2bDt25RKmJBHA9KtzielwzAA==}
@@ -1774,6 +1777,10 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
+  '@profullstack/form-guard@0.1.0':
+    resolution: {integrity: sha512-2BeyeKCuOmSgVvLY+/GdS30a724VLnlLA5s26rANFWet8IeXFzoiQG5dTWFjo9Xq15ZxxkPK0gYLHH4x0CYTLg==}
+    engines: {node: '>=20'}
+
   '@react-native-async-storage/async-storage@1.21.0':
     resolution: {integrity: sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==}
     peerDependencies:
@@ -1881,6 +1888,7 @@ packages:
 
   '@react-navigation/bottom-tabs@6.6.1':
     resolution: {integrity: sha512-9oD4cypEBjPuaMiu9tevWGiQ4w/d6l3HNhcJ1IjXZ24xvYDSs0mqjUcdt8SWUolCvRrYc/DmNBLlT83bk0bHTw==}
+    deprecated: This version is no longer supported
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'
@@ -1890,11 +1898,13 @@ packages:
 
   '@react-navigation/core@6.4.17':
     resolution: {integrity: sha512-Nd76EpomzChWAosGqWOYE3ItayhDzIEzzZsT7PfGcRFDgW5miHV2t4MZcq9YIK4tzxZjVVpYbIynOOQQd1e0Cg==}
+    deprecated: This version is no longer supported
     peerDependencies:
       react: '*'
 
   '@react-navigation/elements@1.3.31':
     resolution: {integrity: sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==}
+    deprecated: This version is no longer supported
     peerDependencies:
       '@react-navigation/native': ^6.0.0
       react: '*'
@@ -1912,12 +1922,14 @@ packages:
 
   '@react-navigation/native@6.1.18':
     resolution: {integrity: sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==}
+    deprecated: This version is no longer supported
     peerDependencies:
       react: '*'
       react-native: '*'
 
   '@react-navigation/routers@6.1.9':
     resolution: {integrity: sha512-lTM8gSFHSfkJvQkxacGM6VJtBt61ip2XO54aNfswD+KMw6eeZ4oehl7m0me3CR9hnDE4+60iAZR8sAhvCiI3NA==}
+    deprecated: This version is no longer supported
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -2304,6 +2316,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@urql/core@2.3.6':
     resolution: {integrity: sha512-PUxhtBh7/8167HJK6WqBv6Z0piuiaZHQGYbhwpNL9aIQmLROPEdaUYkY4wh45wPQXcTpnd11l0q3Pw+TI11pdw==}
@@ -2347,6 +2360,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -8323,6 +8337,8 @@ snapshots:
     dependencies:
       inquirer: 10.2.2
       sharp: 0.33.5
+
+  '@profullstack/form-guard@0.1.0': {}
 
   '@react-native-async-storage/async-storage@1.21.0(react-native@0.73.4(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react@18.2.0))':
     dependencies:


### PR DESCRIPTION
## What happened

A contact-form submission arrived from `madamtaisia@mail.ru` claiming to be "Isabella Thompson", with a contentless body. It passed SPF, DKIM, DMARC and ARC — because the site mails *itself* through its own Resend/SES path, so the cryptography validates our infrastructure, never the submitter.

The form already had a working honeypot. It did not fail. The sender POSTed straight at `/api/contact`, so the hidden `website` field was **absent from the body rather than filled**, and "is it empty?" answered yes. A honeypot only catches a bot that renders your page, and most of them do not.

No mail filter can catch this for us: the message is auth-clean and self-originated. The fix belongs at the form.

## What this does

Adds [`@profullstack/form-guard`](https://github.com/profullstack/form-guard), written for this. Its primary check is a **signed proof-of-render token** minted when the page renders and required on submit — no page load, no token, no send. The token carries its issue time, which gives a fill-time floor for free.

| Layer | Catches | On failure |
|---|---|---|
| Proof-of-render token | Direct-to-endpoint bots | silently dropped, reported as success |
| Fill-time floor (3s) | Instant submits | asked to resend |
| Honeypot | Bots that do render | silently dropped |
| Rate limit (5/hr/IP) | Floods | 429 |
| Content scoring | Low-effort lead bait | **delivered**, subject tagged `[spam? N]` |

Only the first four block. Content scoring can tag a message but **never drop one** — every signal it reads has an innocent explanation.

Delivered mail now carries the submitter's IP, user-agent, fill time and which signals fired. None of that is in the headers today.

## Notes

- Spam checks run **before** field validation on purpose: a bot that gets "all fields are required" back has learned what to send next time.
- Guard config is shared between page and route (`lib/contact-guard.js`) so the binding and field names cannot drift — a mismatch would reject every real submission silently.
- `/contact` is now `force-dynamic`; a cached page would hand every visitor the same stale token.
- The honeypot moved from `display:none` to off-canvas positioning — some bots skip fields they can tell are not rendered.

## Config

**No new env vars required.** The secret falls back to `RESEND_API_KEY`, which this route already cannot work without and which is identical across instances. Set `FORM_GUARD_SECRET` to make it independent. `FORM_GUARD_ENFORCE=0` drops back to scoring-only if a real sender ever reports being turned away.

## Testing

`pnpm build` passes; `/contact` renders dynamic. Against the running app with a dummy Resend key, so a drop returns 200 without ever calling Resend and an accept reaches Resend and 502s:

| Case | Result |
|---|---|
| The real spam, posted directly with no token | `200` to caller, `dropped submission (token_missing)`, Resend never called |
| Real browser flow, token, 5s fill | reached Resend → `502` on the dummy key |
| Valid token submitted instantly | `400` "please send it again" |
| Valid token + filled honeypot | `200` to caller, `dropped submission (honeypot)` |

The package itself has 27 tests covering token forgery, cross-form replay, tampering, expiry, sliding-window rate limits and the scoring layer — including an assertion that the real message is flagged but still delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5K2AxX2QZ98JW1Exe5wup
